### PR TITLE
[DO NOT MERGE] experiment for windows crash

### DIFF
--- a/nimterop.nimble
+++ b/nimterop.nimble
@@ -7,6 +7,7 @@ license     = "MIT"
 
 bin = @["toast"]
 installDirs = @["nimterop"]
+installFiles = @["toast.nim", "config.nims"]
 
 # Dependencies
 

--- a/nimterop/cimport.nim
+++ b/nimterop/cimport.nim
@@ -88,7 +88,19 @@ proc getToast(fullpath: string, recurse: bool = false): string =
     ret = 0
     cmd = when defined(Windows): "cmd /c " else: ""
 
-  cmd &= "toast --pnim --preprocess"
+  let toast_temp = currentSourcePath.parentDir / ("toast_temp".addFileExt ExeExt)
+  block:
+    let toastSrcPath = currentSourcePath.parentDir.parentDir / "toast.nim"
+    let cmd2 = &"nim c -o:{toast_temp} {toastSrcPath}"
+    echo "getToast:"
+    echo cmd2
+    let (result2, ret2) = gorgeEx(cmd2)
+    echo result2
+    echo "ret2:" & $ret2
+    doAssert ret2 == 0
+    # (result, ret) = gorgeEx(cmd, cache=getCacheValue(fullpath))
+
+  cmd &= &"{toast_temp} --pnim --preprocess"
 
   if recurse:
     cmd.add " --recurse"


### PR DESCRIPTION
this illustrates a pre-existing bug, maybe it's nimterop or nim bug,

`import segfaults` + `--debugger:native` helps debugging it a bit

```
cligen.nim(656)          toast
cligen.nim(570)          dispatchmain
toast.nim(147)           main
toast.nim(100)           process
ast.nim(148)             printNim
ast.nim(100)             searchAst
grammar.nim(85)          :anonymous
getters.nim(106)         getIdentifier
gc.nim(473)              newObjNoInit
alloc.nim(781)           rawAlloc
Error: unhandled exception:  [NilAccessError]
```


when the code is modified a bit the error moves around
```
cligen.nim(656)          toast
cligen.nim(570)          dispatchmain
toast.nim(147)           main
toast.nim(100)           process
ast.nim(148)             printNim
ast.nim(99)              searchAst
ast.nim(76)              searchAstForNode
ast.nim(76)              searchAstForNode
ast.nim(76)              searchAstForNode
ast.nim(76)              searchAstForNode
ast.nim(85)              searchAstForNode
ast.nim(37)              saveNodeData
gc.nim(484)              newSeq
gc.nim(477)              newObj
alloc.nim(781)           rawAlloc
Error: unhandled exception:  [NilAccessError]
```

seems like GC is in a bad state

this happens when we're using a nim binary (toast) that was compiled at CT

```
Resetting C:\Users\appveyor\.nimble\pkgs\nimterop-0.1.0\build\inc\treesitter
Resetting C:\Users\appveyor\.nimble\pkgs\nimterop-0.1.0\build\inc\utf8proc
Hint: types [Processing]
Hint: unittest [Processing]
Hint: terminal [Processing]
Hint: colors [Processing]
Importing c:/binaries/mingw32/bin/../lib/gcc/i686-w64-mingw32/8.1.0/../../../../i686-w64-mingw32/include/math.h
(Field0: "getToastExe", Field1: "nim c -o:C:\\Users\\appveyor\\.nimble\\pkgs\\nimterop-0.1.0\\nimterop\\nimterop\\toast C:\\Users\\appveyor\\.nimble\\pkgs\\nimterop-0.1.0\\nimterop\\toast.nim")
cmd /c C:\Users\appveyor\.nimble\pkgs\nimterop-0.1.0\nimterop\nimterop\toast --pnim --preprocess --pluginSourcePath=C:\Users\appveyor\AppData\Local\Temp\1\nimterop_3688256538.nim c:/binaries/mingw32/bin/../lib/gcc/i686-w64-mingw32/8.1.0/../../../../i686-w64-mingw32/include/math.h
stack trace: (most recent call last)
..\..\..\Users\appveyor\.nimble\pkgs\nimterop-0.1.0\nimterop\cimport.nim(448) cImport
..\..\..\Users\appveyor\.nimble\pkgs\nimterop-0.1.0\nimterop\cimport.nim(132) getToast
..\..\..\..\c:\binaries\nim-0.19.2\lib\system.nim(3877) failedAssertImpl
..\..\..\..\c:\binaries\nim-0.19.2\lib\system.nim(3870) raiseAssert
..\..\..\..\c:\binaries\nim-0.19.2\lib\system.nim(2916) sysFatal
tmath.nim(20, 9) template/generic instantiation from here
c:\binaries\nim-0.19.2\lib\system.nim(2916, 7) Error: unhandled exception: C:\Users\appveyor\.nimble\pkgs\nimterop-0.1.0\nimterop\cimport.nim(132, 12) `ret == 0` # Generated at 2019-01-29T08:44:43+00:00
# Command line:
#   C:\Users\appveyor\.nimble\pkgs\nimterop-0.1.0\nimterop\nimterop\toast.exe --pnim --preprocess --pluginSourcePath=C:\Users\appveyor\AppData\Local\Temp\1\nimterop_3688256538.nim c:/binaries/mingw32/bin/../lib/gcc/i686-w64-mingw32/8.1.0/../../../../i686-w64-mingw32/include/math.h
{.experimental: "codeReordering".}
No stack traceback available
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
stack trace: (most recent call last)
C:\projects\nimterop\nimterop.nimble(54) testTask
C:\projects\nimterop\nimterop.nimble(41) testAll
C:\projects\nimterop\nimterop.nimble(21) execCmd
c:\binaries\nim-0.19.2\lib\system\nimscript.nim(237) exec
c:\binaries\nim-0.19.2\lib\system\nimscript.nim(237, 7) Error: unhandled exception: FAILED: nim c -r tests/tmath.nim
Command exited with code 1
7z a -r buildlogs-win-pkgs.zip %USERPROFILE%\.nimble\pkgs
7-Zip 18.05 (x64) : Copyright (c) 1999-2018 Igor Pavlov : 2018-04-30
Scanning the drive:
238 folders, 473 files, 31880808 bytes (31 MiB)
```
