### PR TITLE
fix #90 run tests without -d:release instead of both with and without

### DIFF
--- a/nimterop.nimble
+++ b/nimterop.nimble
@@ -44,7 +44,9 @@ proc testAll() =
     tsoloud() # requires some libraries on linux, need them installed in TRAVIS
 
 task test, "Test":
-  for options in ["", "-d:release"]:
+  # consider running each test under `nim c` and `nim cpp` modes; some additional
+  # c++ specific tests can also run for `nim cpp` mode.
+  for options in [""]:
     buildToast(options)
     testAll()
 


### PR DESCRIPTION
* fix #90

completely non-scientific measurement, see below

time saving isn't huge but is something nevertheless;
i expect a lot more tests to be added over time so this may be useful

## after PR:

![image](https://user-images.githubusercontent.com/2194784/51968806-b4f83280-2427-11e9-8731-f18e2d6411b6.png)

![image](https://user-images.githubusercontent.com/2194784/51968823-c17c8b00-2427-11e9-870a-a52390860da9.png)



## before PR (or rather, for https://github.com/genotrance/nimterop/pull/88 which shouldn't have any impact on time):

![image](https://user-images.githubusercontent.com/2194784/51968882-de18c300-2427-11e9-94f6-df82a8a3e411.png)

![image](https://user-images.githubusercontent.com/2194784/51968897-e7099480-2427-11e9-81e7-dbca49f7027c.png)

