### PR TITLE
fix deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,12 @@ addons:
 language: c
 
 env:
-  - BRANCH=0.19.6
   - BRANCH=0.20.2
   - BRANCH=1.0.4
   - BRANCH=devel
 
 cache:
   directories:
-    - "$HOME/.choosenim/toolchains/nim-0.19.6"
     - "$HOME/.choosenim/toolchains/nim-0.20.2"
     - "$HOME/.choosenim/toolchains/nim-1.0.4"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ matrix:
 
 environment:
   matrix:
-    - NIM_VERSION: 0.19.6
     - NIM_VERSION: 0.20.2
     - NIM_VERSION: 1.0.4
 

--- a/nimterop/getters.nim
+++ b/nimterop/getters.nim
@@ -24,7 +24,7 @@ using
 var
 when while
 xor
-yield""".split(Whitespace).toSet()
+yield""".split(Whitespace).toHashSet()
 
 const gTypeMap* = {
   # char

--- a/nimterop/globals.nim
+++ b/nimterop/globals.nim
@@ -17,7 +17,7 @@ const
     "primitive_type",
     "sized_type_specifier",
     "type_identifier"
-  ].toSet()
+  ].toHashSet()
 
   gExpressions {.used.} = @[
     "parenthesized_expression",
@@ -25,7 +25,7 @@ const
     "shift_expression",
     "math_expression",
     "escape_sequence"
-  ].toSet()
+  ].toHashSet()
 
   gEnumVals {.used.} = @[
     "identifier",

--- a/nimterop/plugin.nim
+++ b/nimterop/plugin.nim
@@ -6,17 +6,17 @@ type
     parent*: string
     kind*: NimSymKind
     override*: string
-
+  StringHash = HashSet[string]
   OnSymbol* = proc(sym: var Symbol) {.cdecl.}
-  OnSymbolOverrideFinal* = proc(typ: string): HashSet[string] {.cdecl.}
+  OnSymbolOverrideFinal* = proc(typ: string): StringHash {.cdecl.}
 
 var
-  cOverrides*: Table[string, HashSet[string]]
+  cOverrides*: Table[string, StringHash]
 
-cOverrides = initTable[string, HashSet[string]]()
-cOverrides["nskType"] = initSet[string]()
-cOverrides["nskConst"] = initSet[string]()
-cOverrides["nskProc"] = initSet[string]()
+cOverrides = initTable[string, StringHash]()
+cOverrides["nskType"] = StringHash()
+cOverrides["nskConst"] = StringHash()
+cOverrides["nskProc"] = StringHash()
 
-proc onSymbolOverrideFinal*(typ: string): HashSet[string] {.exportc, dynlib.} =
+proc onSymbolOverrideFinal*(typ: string): StringHash {.exportc, dynlib.} =
   result = cOverrides[typ]


### PR DESCRIPTION
* fixes deprecation warnings; and uses fact that hashsets now auto-initialize
* drops support for old 0.19.6; it's plenty old and prevents using the new toHashSet