### PR TITLE
Some small compatibility fixes for FreeBSD

### DIFF
--- a/nimterop/build.nim
+++ b/nimterop/build.nim
@@ -358,7 +358,7 @@ proc findFile*(file: string, dir: string, recurse = true, first = false, regex =
         "nimgrep --filenames --oneline --nocolor $1 \"$2\" $3"
       elif defined(linux):
         "find $3 $1 -regextype egrep -regex $2"
-      elif defined(osx):
+      elif defined(osx) or defined(FreeBSD):
         "find -E $3 $1 -regex $2"
 
     recursive = ""

--- a/nimterop/build.nim
+++ b/nimterop/build.nim
@@ -754,7 +754,7 @@ proc getNumProcs(): string =
     getEnv("NUMBER_OF_PROCESSORS").strip()
   elif defined(linux):
     execAction("nproc").output.strip()
-  elif defined(macosx):
+  elif defined(macosx) or defined(FreeBSD):
     execAction("sysctl -n hw.ncpu").output.strip()
   else:
     "1"
@@ -830,7 +830,7 @@ proc buildLibrary(lname, outdir, conFlags, cmakeFlags, makeFlags: string): strin
 proc getDynlibExt(): string =
   when defined(windows):
     result = ".dll"
-  elif defined(linux):
+  elif defined(linux) or defined(FreeBSD):
     result = ".so[0-9.]*"
   elif defined(macosx):
     result = ".dylib[0-9.]*"

--- a/nimterop/cimport.nim
+++ b/nimterop/cimport.nim
@@ -82,7 +82,7 @@ proc getFileDate(fullpath: string): string =
         &"cmd /c for %a in ({fullpath.sanitizePath}) do echo %~ta"
       elif defined(Linux):
         &"stat -c %y {fullpath.sanitizePath}"
-      elif defined(OSX):
+      elif defined(OSX) or defined(FreeBSD):
         &"stat -f %m {fullpath.sanitizePath}"
 
   (result, ret) = execAction(cmd)


### PR DESCRIPTION
Hello,

I want to thank you for developing nimterop, it is a great piece of art! :-)

Using nimterop on FreeBSD I encountered some small problems, with easy fixes.
MacOS and FreeBSD seem to use the same version of the 'stat' and 'find' command line tools, so checking for FreeBSD in the when statements is all that is needed. Both also share the sysctl hw.ncpu. 
However FreeBSD uses .so as an extension for dynamic libraries, just like Linux.

Initial tests on my machine fixed the problems I ran into before.

I found these problems incrementally, so maybe it would be better to put them all into one big commit?
If there is anything else I should change in this pull request, please let me know.