### PR TITLE
add case for file pointers

### DIFF
--- a/nimterop/ast2.nim
+++ b/nimterop/ast2.nim
@@ -12,6 +12,8 @@ proc getPtrType*(str: string): string =
   result = case str:
     of "cchar":
       "cstring"
+    of "FILE":
+      "File"
     of "object":
       "pointer"
     else:


### PR DESCRIPTION
Hello,

`FILE *` pointers from C are converted to `ptr File` in the ast2. As the type `File = ptr CFile` this is not what is intended. As it is similar to the case of pointers to char arrays being converted to `cstring`s, I added a case for `FILE` to the getPtrType `proc`

In my tests this results in a correct translation of `FILE *file` to `file: File` instead of `file: ptr File`

EDIT:
The failing test in travis-ci is again on MacOS for the devel version of Nim. Nimble is missing there, so I guess this is a problem of the CI setup and not my commit? At least all other tests pass.