### PR TITLE
Fix function type with const return value

### DIFF
--- a/nimterop/ast2.nim
+++ b/nimterop/ast2.nim
@@ -1238,7 +1238,11 @@ proc addType(gState: State, node: TSNode, union = false) =
         gState.addTypeObject(node[0], union = union)
       else:
         let
-          fdecl = node[1].anyChildInTree("function_declarator")
+          fdecl =
+            if node.len >= 3:
+              node[2].anyChildInTree("function_declarator")
+            else:
+              node[1].anyChildInTree("function_declarator")
           adecl = node[1].anyChildInTree("array_declarator")
         if fdlist.isNil:
           if adecl.isNil and fdecl.isNil:

--- a/tests/include/tast2.h
+++ b/tests/include/tast2.h
@@ -107,6 +107,8 @@ typedef struct A20 { char a1; } A20, A21, *A21p;
 //Expression
 typedef struct A22 { const int **f1; int *f2[123+132]; } A22;
 
+typedef const char *(*A23)();
+
 //Unions
 union U1 {int f1; float f2; };
 typedef union U2 { const int **f1; int abc[123+132]; } U2;

--- a/tests/tast2.nim
+++ b/tests/tast2.nim
@@ -332,6 +332,10 @@ checkPragmas(A22, pHeaderBy, istype = false)
 var a22: A22
 a22.f1 = addr a15.a2[0]
 
+assert A23 is proc(): cstring {.cdecl.}
+checkPragmas(A23, pHeaderImp & "cdecl")
+var a23: A23
+
 assert U1 is object
 assert sizeof(U1) == sizeof(cfloat)
 checkPragmas(U1, pHeaderBy & @["union"], istype = false)


### PR DESCRIPTION
Before the fix

    typedef const char *(*foobar)();

was transformed to

    type
        foobar* {.importc, impbrokenHdr.} = cstring

After the fix

    type
        foobar* {.importc, impbrokenHdr.} = proc (): cstring {.cdecl.}

I'm not sure if this could be fixed better, but this seems to not break anything.