### PR TITLE
run 'buildToast' without 'timeit'

### DIFF
--- a/nimterop.nimble
+++ b/nimterop.nimble
@@ -34,7 +34,7 @@ task buildTimeit, "build timer":
   exec "nim c --hints:off -d:danger tests/timeit"
 
 task buildToast, "build toast":
-  execCmd("nim c --hints:off -d:danger nimterop/toast.nim")
+  exec "nim c --hints:off -d:danger nimterop/toast.nim"
 
 task bt, "build toast":
   buildToastTask()


### PR DESCRIPTION
When `buildToast` is run as the first/only command, there's no `tests/timeit` binary, so the test immediately fails.