### PR TITLE
Fix #233: make shl/shr use the direct left operand for type casting

### DIFF
--- a/tests/include/tast2.h
+++ b/tests/include/tast2.h
@@ -35,6 +35,7 @@ extern "C" {
 #define EQ4 AVAL < BVAL
 #define EQ5 AVAL != BVAL
 #define EQ6 AVAL == BVAL
+#define SX_NEAR_ZERO (1.0f / (1 << 28))
 
 // testing integer out of long int range
 #define INT_FAST16_MIN (-9223372036854775807L-1)

--- a/tests/tast2.nim
+++ b/tests/tast2.nim
@@ -134,6 +134,8 @@ assert EQ4 == (AVAL < BVAL)
 assert EQ5 == (AVAL != BVAL)
 assert EQ6 == (AVAL == BVAL)
 
+assert SX_NEAR_ZERO == 3.725290298461914e-09
+
 assert SIZEOF == 1
 
 assert COERCE == 645635670332'u64


### PR DESCRIPTION
This only partially resolves the issue. The Nim VM now complains about casting an int to a float in this:

```c
#define SX_NEAR_ZERO (1.0f / (float)(1 << 28))
```

But this works now:

```c
#define SX_NEAR_ZERO (1.0f / (1 << 28))
```

Not sure how to resolve the first case.