### PR TITLE
Support Meson

### DIFF
--- a/nimterop/cimport.nim
+++ b/nimterop/cimport.nim
@@ -133,6 +133,7 @@ proc getToast(fullpaths: seq[string], recurse: bool = false, dynlib: string = ""
       (output, ret) = execAction(cmd, die = false)
     if ret != 0:
       # If toast fails, print failure to output and delete any generated files
+      echo "XXX ", cmd, " ", output
       let errout = if result.fileExists(): result.readFile() & output else: output
       rmFile(result)
       doAssert false, "\n\n" & errout & "\n"

--- a/nimterop/globals.nim
+++ b/nimterop/globals.nim
@@ -87,7 +87,7 @@ type
       searchDirs*: seq[string]   # `cSearchPath()` added directories for header search
 
   BuildType* = enum
-    btAutoconf, btCmake
+    btAutoconf, btCmake, btMeson
 
   BuildStatus* = object
     built*: bool


### PR DESCRIPTION
Working on a wrapper for dav1d, a portable video decoder library. Like a few other higher-profile newly created C projects, Dav1d uses the meson build system, so I made a patch.

The wrapper isn't done yet but the library does build, so I created a draft pull request for reference. Please feel free to comment if anything seems obviously out of whack.

Thanks for making nimterop! dav1d went through recursively without a hitch. I didn't need recursive for the nestegg demuxer but it went right through as well.