### PR TITLE
Choose make executable

### DIFF
--- a/nimterop/build/tools.nim
+++ b/nimterop/build/tools.nim
@@ -180,16 +180,25 @@ proc make*(path, check: string, flags = "", regex = false) =
   gecho "# Running make " & flags
   gecho "#   Path: " & path
 
-  var
-    cmd = findExe("make")
+  const
+    makeCmd {.strdefine.} = ""
 
-  if cmd.len == 0:
-    cmd = findExe("mingw32-make")
-    if cmd.len != 0:
-      cpFile(cmd, cmd.replace("mingw32-make", "make"))
-  doAssert cmd.len != 0, "Make not found"
+  when makeCmd.len != 0:
+    var
+      cmd = findExe(makeCmd)
+    doAssert cmd.len != 0, "The make program passed in via -d:makeCmd could not be found!"
+  else:
+    var
+      cmd = findExe("make")
 
-  cmd = &"cd {path.sanitizePath} && make -j {getNumProcs()}"
+    if cmd.len == 0:
+      cmd = findExe("mingw32-make")
+      if cmd.len != 0:
+        cpFile(cmd, cmd.replace("mingw32-make", "make"))
+        cmd = "make"
+    doAssert cmd.len != 0, "Make not found"
+
+  cmd = &"cd {path.sanitizePath} && {cmd} -j {getNumProcs()}"
   if flags.len != 0:
     cmd &= &" {flags}"
 

--- a/nimterop/build/tools.nim
+++ b/nimterop/build/tools.nim
@@ -187,6 +187,10 @@ proc make*(path, check: string, flags = "", regex = false) =
     var
       cmd = findExe(makeCmd)
     doAssert cmd.len != 0, "The make program passed in via -d:makeCmd could not be found!"
+  elif defined(freebsd) or defined(openbsd) or defined(netbsd):
+    var
+      cmd = findExe("gmake")
+    doAssert cmd.len != 0, "Please install GNU make as gmake\nBSD make is not supported"
   else:
     var
       cmd = findExe("make")


### PR DESCRIPTION
Hello,

as there are multiple [variants of make](https://en.wikipedia.org/wiki/Make_(software)#Derivatives) it would probably be sensible to allow the user to select the one they want. Therefore I added a compile-time switch `-d:makeCmd` to enable the user to select the make-binary they want.

As most make-based projects use [GNU make](https://www.gnu.org/software/make/), I also added a small change to use `gmake` by default on BSDs. While they come with BSD make preinstalled, it has some incompatibilities.