### PR TITLE
Whitespace in include folders breaks build

### DIFF
--- a/nimterop/treesitter/api.nim
+++ b/nimterop/treesitter/api.nim
@@ -13,8 +13,8 @@ const sourcePath = cacheDir / "treesitter" / "lib"
 when defined(Linux) and defined(gcc):
   {.passC: "-std=c11".}
 
-{.passC: "-I\"$1\"" % (sourcePath / "include").}
-{.passC: "-I\"$1\"" % (sourcePath / "src").}
+{.passC: ("-I" & quoteShell(sourcePath / "include")) .}
+{.passC: ("-I" & quoteShell(sourcePath / "src")) .}
 
 {.compile: sourcePath / "src" / "lib.c".}
 

--- a/nimterop/treesitter/api.nim
+++ b/nimterop/treesitter/api.nim
@@ -13,8 +13,8 @@ const sourcePath = cacheDir / "treesitter" / "lib"
 when defined(Linux) and defined(gcc):
   {.passC: "-std=c11".}
 
-{.passC: "-I$1" % (sourcePath / "include").}
-{.passC: "-I$1" % (sourcePath / "src").}
+{.passC: "-I\"$1\"" % (sourcePath / "include").}
+{.passC: "-I\"$1\"" % (sourcePath / "src").}
 
 {.compile: sourcePath / "src" / "lib.c".}
 

--- a/nimterop/treesitter/c.nim
+++ b/nimterop/treesitter/c.nim
@@ -9,7 +9,7 @@ const srcDir = cacheDir / "treesitter_c" / "src"
 
 import "."/api
 
-{.passC: "-I$1" % srcDir.}
+{.passC: "-I\"$1\"" % srcDir.}
 
 {.compile: srcDir / "parser.c".}
 

--- a/nimterop/treesitter/c.nim
+++ b/nimterop/treesitter/c.nim
@@ -9,8 +9,8 @@ const srcDir = cacheDir / "treesitter_c" / "src"
 
 import "."/api
 
-{.passC: "-I\"$1\"" % srcDir.}
+{.passC: ("-I" & quoteShell(srcDir)) .}
 
-{.compile: srcDir / "parser.c".}
+{.compile: srcDir / "parser.c" .}
 
 proc treeSitterC*(): ptr TSLanguage {.importc: "tree_sitter_c".}

--- a/nimterop/treesitter/cpp.nim
+++ b/nimterop/treesitter/cpp.nim
@@ -8,7 +8,7 @@ static:
 
 const srcDir = cacheDir / "treesitter_cpp" / "src"
 
-{.passC: "-I\"$1\"" % srcDir.}
+{.passC: ("-I" & quoteShell(srcDir)) .}
 
 import "."/api
 

--- a/nimterop/treesitter/cpp.nim
+++ b/nimterop/treesitter/cpp.nim
@@ -8,7 +8,7 @@ static:
 
 const srcDir = cacheDir / "treesitter_cpp" / "src"
 
-{.passC: "-I$1" % srcDir.}
+{.passC: "-I\"$1\"" % srcDir.}
 
 import "."/api
 


### PR DESCRIPTION
When using windows and using a folder with whitespace in nimterop folder, the build fails.

I got following error messages when performing `nimble build` in a folder containing whitespace:
```
...
Building nimterop/nimterop/toast.exe using c backend
...
# Resetting C:\Users\Firstname Lastname\nimcache\nimterop\nimterop\treesitter_cpp
gcc.exe: error: Lastname\nimcache\nimterop\nimterop\treesitter\lib\include: No such file or directory
...
execution of an external compiler program 'C:\code\nim-1.4.4\dist\mingw64\bin\gcc.exe -c  -w -fmax-errors=3 -mno-ms-bitfields -DWIN32_LEAN_AND_MEAN -IC:\Users\Firstname Lastname\nimcache\nimterop\nimterop\treesitter\lib\include -IC:\Users\Firstname Lastname\nimcache\nimterop\nimterop\treesitter\lib\src -IC:\Users\Firstname Lastname\nimcache\nimterop\nimterop\treesitter_c\src -IC:\Users\Firstname Lastname\nimcache\nimterop\nimterop\treesitter_cpp\src -O3 -fno-strict-aliasing -fno-ident   -IC:\code\nim-1.4.4\lib -IC:\Users\Firstnam~1\AppData\Local\Temp\nimble_6212\githubcom_genotrancenimterop_0.6.12\nimterop -o "C:\Users\Firstname Lastname\nimcache\toast_r\lib.c.o" "C:\Users\Firstname Lastname\nimcache\nimterop\nimterop\treesitter\lib\src\lib.c"' failed with exit code: 1
```
The include folder direction `-Ifolder with whitespace` didn't use any quotes, so the whitespace made gcc expect a filename.
After adding surrounding double quotes `-I"folder with whitespace"` the build finishes without errors on my windows machine.

Build succeeds on windows. Tests still do not work yet when having whitespace, but seem to work when using a folder without whitespace.