### PR TITLE
Reset locale for the compiler commands

### DIFF
--- a/nimterop/build/ccompiler.nim
+++ b/nimterop/build/ccompiler.nim
@@ -27,6 +27,9 @@ proc getCompiler*(): string =
       else:
         doAssert false, "Nimterop only supports gcc and clang at this time"
 
+  when defined(unix):
+    compiler = "LC_ALL=C " & compiler
+
   result = getEnv("CC", compiler)
 
 proc getGccPaths*(mode: string): seq[string] =


### PR DESCRIPTION
Added `LC_ALL=C` for the compiler commands on unix.