### PR TITLE
pass -G"MSYS Makefiles" to cmake if MSYSTEM env var is set

### DIFF
--- a/nimterop/build/tools.nim
+++ b/nimterop/build/tools.nim
@@ -207,7 +207,7 @@ proc buildWithCmake*(outdir, flags: string): BuildStatus =
           if findExe("sh").len != 0:
             let
               uname = execAction("sh -c uname -a").output.toLowerAscii()
-            if uname.contains("msys"):
+            if existsEnv("MSYSTEM") or uname.contains("msys"):
               gen = "MSYS Makefiles".quoteShell
             elif uname.contains("mingw"):
               gen = "MinGW Makefiles".quoteShell & " -DCMAKE_SH=\"CMAKE_SH-NOTFOUND\""


### PR DESCRIPTION
Closes #284

---

This approach works re: fixing the problem I had in #284, but whether there are any negative/unintended consequences for non-MSYS2 Windows environments that have `MSYSTEM` set, I'm not certain.