### PR TITLE
use uint8 instead of cuchar

### DIFF
--- a/nimterop/toastlib/getters.nim
+++ b/nimterop/toastlib/getters.nim
@@ -40,7 +40,7 @@ var
     # char
     "char": "cchar",
     "signed char": "cschar",
-    "unsigned char": "cuchar",
+    "unsigned char": "uint8",
 
     # short
     "short": "cshort",


### PR DESCRIPTION
cuchar was deprecated by https://github.com/nim-lang/Nim/pull/18505