### PR TITLE
Fix a problem with the nimcache directory path.

### DIFF
--- a/nimterop/build/getheader.nim
+++ b/nimterop/build/getheader.nim
@@ -483,7 +483,7 @@ macro getHeader*(
           findFile(`lname`, `outdir`, regex = true)
         else:
           buildLibrary(`lname`, `outdir`, `conFlags`, `cmakeFlags`, `makeFlags`, `buildTypes`)
-
+    
       # Library dependecy paths
       ldeps {.compileTime.}: seq[string] =
         when not useStd:

--- a/nimterop/build/nimconf.nim
+++ b/nimterop/build/nimconf.nim
@@ -23,6 +23,7 @@ type
     nimcacheDir*: string
     outDir*: string
 
+
 proc getJson(projectDir: string): JsonNode =
   # Get `nim dump` json value for `projectDir`
   var
@@ -103,8 +104,17 @@ proc getNimConfig*(projectDir = ""): Config =
       libPath = getCurrentCompilerExe().parentDir().parentDir() / "lib"
       lazyPaths = querySettingSeq(MultipleValueSetting.lazyPaths)
       searchPaths = querySettingSeq(MultipleValueSetting.searchPaths)
+      var 
+        nimcacheDir = querySetting(SingleValueSetting.nimcacheDir) 
+      if not nimcacheDir.isAbsolute():
+        # Relative path will be expanded to absolute
+        # on POSIX and Windows otherwise it will be left as is
+        when defined(posix):
+          nimcacheDir = getEnv("PWD") / nimcacheDir
+        when defined(windows):
+          nimcacheDir = staticExec("cmd /c echo %CD%") / nimcacheDir
       result.nimcacheDir = stripName(
-        querySetting(SingleValueSetting.nimcacheDir),
+        nimcacheDir,
         querySetting(SingleValueSetting.projectName)
       )
       result.outDir = querySetting(SingleValueSetting.outDir)

--- a/nimterop/toastlib/getters.nim
+++ b/nimterop/toastlib/getters.nim
@@ -392,7 +392,7 @@ proc loadPlugin*(gState: State, sourcePath: string) =
       outflags = &"--out:\"{pdll}\""
 
       # Compile plugin as library with `markAndSweep` GC
-      cmd = &"{gState.nim} c --app:lib --gc:markAndSweep {flags} {outflags} {sourcePath.sanitizePath}"
+      cmd = &"{gState.nim} c --app:lib --skipParentCfg:on --gc:markAndSweep {flags} {outflags} {sourcePath.sanitizePath}"
 
       (output, ret) = execAction(cmd, die = false)
     doAssert ret == 0, output & "\nFailed to compile cPlugin()\n\ncmd: " & cmd


### PR DESCRIPTION
Fix a problem with the nimcache directory path. If it was changed to a relative path instead of absolute one the library can't work properly and enters infinite recursion during compilation because it tries to create a directory for caching the shell commands but it gets created on the wrong place and the library tries to create it again with a shell command and this way enters infinite recursion.
![image](https://user-images.githubusercontent.com/9976450/225616839-a99f2b9a-95a0-4327-85ef-14be672dc847.png)
